### PR TITLE
Fix branch name not showing up

### DIFF
--- a/segments/git.fish
+++ b/segments/git.fish
@@ -14,8 +14,8 @@ function FLSEG_GIT
 
 		set -l gitstatus (git status ^ /dev/null | \
 		awk 'BEGIN {d=0; s=0; ns=0; u=0; a=0; b=0};\
-		/On branch .+/ {m=$3}; \
-		/HEAD detached (at|from) .+/ {m=$4;d=1}; \
+		/On branch .+/ {m=$4}; \
+		/HEAD detached (at|from) .+/ {m=$5;d=1}; \
 		/Changes to be committed:/ {s=1}; \
 		/Changes not staged for commit:/ {ns=1}; \
 		/Untracked files:/ {u=1}; \


### PR DESCRIPTION
Found an issue where the variable was not correct. For example, the git status command returns:
```
# On branch fix-git-status
# Changes to be committed:
#   (use "git reset HEAD <file>..." to unstage)
#
#	modified:   segments/git.fish
```

The code needs to select the 4th column, not the third. I believe the HEAD detached state would also need that. I checked the ahead/behind and that functionality already worked correctly.