### PR TITLE
Fishline v3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,44 @@
-fishline
-========
+# fishline
 
 [![Join the chat at https://gitter.im/0rax/fishline](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/0rax/fishline?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-**Powerline prompt for Fish Shell in Fish Shell.**
+**A powerline prompt framework for the fish-shell built in fish-shell.**
 
 ![fishline_preview](https://raw.githubusercontent.com/0rax/fishline/screenshots/prompt.png "Fishline Preview")
 
-Install
--------
-Clone fishline where you want, here in the fish's config folder:
+## Requirements
 
-`git clone https://github.com/0rax/fishline.git/ ~/.config/fish/fishline`
+This framework uses a lot of glyph from Powerline fonts in order to work, you will need to install one of them and select it as your shell font to enjoy this software completely. More information about how to install them can be found in the [Powerline wiki](https://powerline.readthedocs.io/en/latest/installation.html#fonts-installation).
 
-Set in your `config.fish` this fishline path and source it.
+
+## Installation
+### Manually
+
+In order to install fishline, you will need to clone this repository somewhere and specify this path in your `config.fish` file as well as sourcing the `init.fish` file present from the repository.
+
+Here is an example on how to do it, by cloning `fishline` in your `~/.config/fish` folder:
+```sh
+git clone https://github.com/0rax/fishline.git/ ~/.config/fish/fishline
+```
+
+Then modify your ``~/.config/fish/config.fish` and add:
 ```sh
 set FLINE_PATH $HOME/.config/fish/fishline
 source $FLINE_PATH/init.fish
 ```
+
+### Using [Fisherman](https://github.com/fisherman/fisherman)
+
+This is the easiest way to install `fishline` in your fish-shell environment. Fisherman will install it and link all the needed functions for you by running the following command:
+
+```sh
+fisher i 0rax/fishline
+```
+
+This will allow you to use the `fishline` command directly and access to all the possible theming / configuration available as if you installed it manually.
+
+## Configuration
+
 
 Now call the fishline function with your last status in your `fish_prompt` function
 ```sh

--- a/segments/__flseg_exectime.fish
+++ b/segments/__flseg_exectime.fish
@@ -13,7 +13,7 @@ function __flseg_exectime
         if [ $duration -gt 36000000 ]
             set -l h   (math "$duration/36000000")
             set -l min (math "$duration/60000%60")
-            printf "%hh %sm" $h $min
+            printf "%sh %sm" $h $min
         else if [ $duration -gt 60000 ]
             set -l min (math "$duration/60000")
             set -l s   (math "$duration/1000%60")

--- a/tests/fltest_exectime.fish
+++ b/tests/fltest_exectime.fish
@@ -19,4 +19,8 @@ function fltest_exectime
     set -gx CMD_DURATION 162320
     __fishline_test EXECTIME
 
+    echo "Context: Last command took 72162042ms to complete"
+    set -gx CMD_DURATION 72162042
+    __fishline_test EXECTIME
+
 end


### PR DESCRIPTION
## Description

This new version of `fishline` contains a bugfix for the `exectime` segment where a long lasting command (> 1 hour) would cause the segment to show nothing and throw a `%hh : invalid conversion specification` error.

## Changelog
### Bugfixes
- Update `exectime` segment to fix the faulty printf format string when `CMD_DURATION` was greater than `36000000` second causing the text to not show the correct time (i.e.: `1h 24m`) but nothing instead.
- Update `exectime` test case to include a case with `CMD_DURATION` greater than `36000000`.

### Minor changes
- Update `README` to include new ways to install `fishline` (Manually and using `fisherman`)
