### PR TITLE
added conda environment segment to match vfish

### DIFF
--- a/segments/__flseg_conda.fish
+++ b/segments/__flseg_conda.fish
@@ -1,0 +1,11 @@
+#!/usr/bin/env fish
+# -*-  mode:fish; tab-width:4  -*-
+
+function __flseg_conda
+
+    if set -q CONDA_DEFAULT_ENV
+        __fishline_segment $FLCLR_CONDA_BG $FLCLR_CONDA_FG
+        printf $FLSYM_CONDA" "(basename $CONDA_DEFAULT_ENV)
+    end
+
+end

--- a/themes/default_256_colors.fish
+++ b/themes/default_256_colors.fish
@@ -39,6 +39,10 @@ set FLCLR_ROOT_FG_ROOT      white
 set FLCLR_VFISH_BG          $__256_green
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          $__256_green
+set FLCLR_CONDA_FG          black
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      $__256_yellow
 set FLCLR_GIT_FG_CLEAN      black

--- a/themes/default_ansi_colors.fish
+++ b/themes/default_ansi_colors.fish
@@ -31,6 +31,10 @@ set FLCLR_ROOT_FG_ROOT      normal
 set FLCLR_VFISH_BG          green
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          green
+set FLCLR_CONDA_FG          black
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      yellow
 set FLCLR_GIT_FG_CLEAN      black

--- a/themes/default_symbols.fish
+++ b/themes/default_symbols.fish
@@ -33,6 +33,9 @@ set FLSYM_ROOT_USER         "\u2192"
 # Symbol for VFISH segment
 set FLSYM_VFISH             "\u2635"
 
+# Symbol for CONDA segment
+set FLSYM_CONDA             "\u2635"
+
 # Symbol for VIMODE segment
 set FLSYM_VIMODE_DEFAULT    "NORMAL"
 set FLSYM_VIMODE_INSERT     "INSERT"

--- a/themes/legacy_256_colors.fish
+++ b/themes/legacy_256_colors.fish
@@ -31,6 +31,10 @@ set FLCLR_ROOT_FG_ROOT      normal
 set FLCLR_VFISH_BG          green
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          green
+set FLCLR_CONDA_FG          black
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      yellow
 set FLCLR_GIT_FG_CLEAN      black

--- a/themes/tty_compatible.fish
+++ b/themes/tty_compatible.fish
@@ -36,6 +36,9 @@ set FLSYM_ROOT_USER         "\$"
 # Symbol for VFISH segment
 set FLSYM_VFISH             "#"
 
+# Symbol for CONDA segment
+set FLSYM_CONDA             "#"
+
 # Symbol for VIMODE segment
 set FLSYM_VIMODE_DEFAULT    "NORMAL"
 set FLSYM_VIMODE_INSERT     "INSERT"

--- a/themes/washed.fish
+++ b/themes/washed.fish
@@ -34,6 +34,10 @@ set FLCLR_ROOT_FG_ROOT      $FLCLR_PWD_FG
 set FLCLR_VFISH_BG          AFD787
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          AFD787
+set FLCLR_CONDA_FG          black
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      AFD787
 set FLCLR_GIT_FG_CLEAN      262626


### PR DESCRIPTION
This PR adds a segment for anaconda environments, as an alternative to virtual environments.

Since the two serve roughly the same purpose, and are not often used simultaneously, I simply copied over the theme colorings from vfish to conda.  I'm happy to change them to something else if need be though.