### PR TITLE
Fishline v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here is an example on how to do it, by cloning `fishline` in your `~/.config/fis
 git clone https://github.com/0rax/fishline.git/ ~/.config/fish/fishline
 ```
 
-Then modify your ``~/.config/fish/config.fish` and add:
+Then modify your `~/.config/fish/config.fish` and add:
 ```sh
 set FLINE_PATH $HOME/.config/fish/fishline
 source $FLINE_PATH/init.fish

--- a/internals/__fishline_test.fish
+++ b/internals/__fishline_test.fish
@@ -16,8 +16,9 @@ function __fishline_test --argument-names segment -d 'test segments'
         fishline -l -s $FLINT_TEST_STATUS $FLINT_TEST_SEG
     end
 
-    read -R flint_test_right -p flint_test_left
+    read -R flint_test_right -p flint_test_left TEST_VAR
 
+    set -e FLINT_TEST_VAR
     set -e FLINT_TEST_SEG
     set -e FLINT_TEST_STATUS
 

--- a/segments/__flseg_conda.fish
+++ b/segments/__flseg_conda.fish
@@ -5,7 +5,7 @@ function __flseg_conda
 
     if set -q CONDA_DEFAULT_ENV
         __fishline_segment $FLCLR_CONDA_BG $FLCLR_CONDA_FG
-        printf $FLSYM_CONDA" "(basename $CONDA_DEFAULT_ENV)
+        printf "$FLSYM_CONDA"(basename $CONDA_DEFAULT_ENV)
     end
 
 end

--- a/segments/__flseg_conda.fish
+++ b/segments/__flseg_conda.fish
@@ -1,0 +1,11 @@
+#!/usr/bin/env fish
+# -*-  mode:fish; tab-width:4  -*-
+
+function __flseg_conda
+
+    if set -q CONDA_DEFAULT_ENV
+        __fishline_segment $FLCLR_CONDA_BG $FLCLR_CONDA_FG
+        printf $FLSYM_CONDA" "(basename $CONDA_DEFAULT_ENV)
+    end
+
+end

--- a/segments/__flseg_pwd.fish
+++ b/segments/__flseg_pwd.fish
@@ -3,15 +3,18 @@
 
 function __flseg_pwd
 
-    set -l pwd (prompt_pwd | sed -E 's;/?([^/]+)/;\1'\u1F';g' | tr \u1F '\n')
+    set -l pwd (prompt_pwd | sed -E 's;/?([^/]+)/?;\1'\u1F';g' | tr \u1F '\n')
 
     set -l it 1
-    set -l len (count $pwd)
+    set -l len (expr (count $pwd) - 1)
 
     if [ "$pwd[1]" = "~" ]
         __fishline_segment $FLCLR_PWD_BG_HOME $FLCLR_PWD_FG_HOME
         printf "~"
         set it 2
+    else if [ "$pwd[1]" = "/" ]
+        __fishline_segment $FLCLR_PWD_BG $FLCLR_PWD_FG
+        printf "/"
     end
 
     if [ $it -le $len ]

--- a/segments/__flseg_screen.fish
+++ b/segments/__flseg_screen.fish
@@ -5,7 +5,7 @@ function __flseg_screen
 
     if set -q STY
         __fishline_segment $FLCLR_SCREEN_BG $FLCLR_SCREEN_FG
-        printf $FLSYM_SCREEN" "(echo $STY | cut -d'.' -f2-)
+        printf "$FLSYM_SCREEN"(echo $STY | cut -d'.' -f2-)
     end
 
 end

--- a/segments/__flseg_screen.fish
+++ b/segments/__flseg_screen.fish
@@ -1,0 +1,11 @@
+#!/usr/bin/env fish
+# -*-  mode:fish; tab-width:4  -*-
+
+function __flseg_screen
+
+    if set -q STY
+        __fishline_segment $FLCLR_SCREEN_BG $FLCLR_SCREEN_FG
+        printf $FLSYM_SCREEN" "(echo $STY | cut -d'.' -f2-)
+    end
+
+end

--- a/segments/__flseg_vfish.fish
+++ b/segments/__flseg_vfish.fish
@@ -5,7 +5,7 @@ function __flseg_vfish
 
     if set -q VIRTUAL_ENV
         __fishline_segment $FLCLR_VFISH_BG $FLCLR_VFISH_FG
-        printf $FLSYM_VFISH" "(basename $VIRTUAL_ENV)
+        printf "$FLSYM_VFISH"(basename $VIRTUAL_ENV)
     end
 
 end

--- a/tests/fltest_conda.fish
+++ b/tests/fltest_conda.fish
@@ -1,0 +1,10 @@
+#!/usr/bin/env fish
+# -*-  mode:fish; tab-width:4  -*-
+
+function fltest_conda
+
+    echo "Context: CONDA_DEFAULT_ENV var is set to 'fishline_test'"
+    set -gx CONDA_DEFAULT_ENV fishline_test
+    __fishline_test CONDA
+
+end

--- a/tests/fltest_fullpwd.fish
+++ b/tests/fltest_fullpwd.fish
@@ -7,11 +7,11 @@ function fltest_fullpwd
     echo "Context: Current Working Directory is '/'"
     cd /
     __fishline_test FULLPWD
-    echo "Context: Current Working Directory is '/tmp'"
-    cd /tmp
+    echo "Context: Current Working Directory is '/dev'"
+    cd /dev
     __fishline_test FULLPWD
-    echo "Context: Current Working Directory is '/var/log'"
-    cd /var/log
+    echo "Context: Current Working Directory is '/usr/local/bin'"
+    cd /usr/local/bin
     __fishline_test FULLPWD
     echo "Context: Current Working Directory is '$HOME'"
     cd $HOME

--- a/tests/fltest_pwd.fish
+++ b/tests/fltest_pwd.fish
@@ -7,11 +7,11 @@ function fltest_pwd
     echo "Context: Current Working Directory is '/'"
     cd /
     __fishline_test PWD
-    echo "Context: Current Working Directory is '/tmp'"
-    cd /tmp
+    echo "Context: Current Working Directory is '/dev'"
+    cd /dev
     __fishline_test PWD
-    echo "Context: Current Working Directory is '/var/log'"
-    cd /var/log
+    echo "Context: Current Working Directory is '/usr/local/bin'"
+    cd /usr/local/bin
     __fishline_test PWD
     echo "Context: Current Working Directory is '$HOME'"
     cd $HOME

--- a/tests/fltest_screen.fish
+++ b/tests/fltest_screen.fish
@@ -1,0 +1,18 @@
+#!/usr/bin/env fish
+# -*-  mode:fish; tab-width:4  -*-
+
+function fltest_screen
+
+    echo "Context: STY var is set to 'fishline_test'"
+    # Test for custom session names
+    set -gx STY 76230.test123
+    __fishline_test SCREEN
+
+    # Automated OSX-style name
+    set -gx STY 69359.ttys001.Providence
+    __fishline_test SCREEN
+
+    # Automated linux-style name
+    set -gx STY 20424.pts-0.userctl
+    __fishline_test SCREEN
+end

--- a/tests/fltest_screen.fish
+++ b/tests/fltest_screen.fish
@@ -3,16 +3,16 @@
 
 function fltest_screen
 
-    echo "Context: STY var is set to 'fishline_test'"
-    # Test for custom session names
-    set -gx STY 76230.test123
+    echo "Context: STY var is set to '76230.fishline_test' (custom session name)"
+    set -gx STY 76230.fishline_test
     __fishline_test SCREEN
 
-    # Automated OSX-style name
-    set -gx STY 69359.ttys001.Providence
+    echo "Context: STY var is set to '69359.ttys001.MacbookPro' (automated OSX session name)"
+    set -gx STY 69359.ttys001.MacbookPro
     __fishline_test SCREEN
 
-    # Automated linux-style name
-    set -gx STY 20424.pts-0.userctl
+    echo "Context: STY var is set to '20424.pts-0.debian' (automated Linux session name)"
+    set -gx STY 20424.pts-0.debian
     __fishline_test SCREEN
+
 end

--- a/tests/fltest_vfish.fish
+++ b/tests/fltest_vfish.fish
@@ -3,8 +3,8 @@
 
 function fltest_vfish
 
-    echo "Context: VIRTUAL_ENV var is set to 'fishline_test'"
-    set -gx VIRTUAL_ENV fishline_test
+    echo "Context: VIRTUAL_ENV var is set to '/Users/me/.virtualenvs/fishline_test'"
+    set -gx VIRTUAL_ENV /Users/me/.virtualenvs/fishline_test
     __fishline_test VFISH
 
 end

--- a/tests/run.fish
+++ b/tests/run.fish
@@ -55,7 +55,7 @@ while [ (count $args) -ge 0 ]
 end
 
 # Init fishline
-set -l FLINE_PATH (dirname (status -f))/..
+set -l FLINE_PATH (git rev-parse --show-toplevel)
 source $FLINE_PATH/init.fish
 set -l fish_function_path $fish_function_path $FLINE_PATH/tests
 

--- a/tests/run.fish
+++ b/tests/run.fish
@@ -28,6 +28,13 @@ Argument and Options:
 
 end
 
+function println
+
+    printf '%*s\r' (tput cols) '' | tr ' ' _
+    printf '__ %s \n\n' $argv
+
+end
+
 set -l segments
 set -l themes
 set -l all_seg false
@@ -71,24 +78,20 @@ end
 echo
 
 # Load themes
-[ "$themes" != "" ]; and echo
 for theme in $themes
-    printf '%*s\r' (tput cols) '' | tr ' ' -
-    printf "-- Loading theme: %s --\n" $theme
-    source $theme
+    println "Loading theme: $theme"
 end
 
 # Run tests
 for seg in (echo $segments | tr 'A-Z' 'a-z' | tr ' ' '\n')
-    printf '%*s\r' (tput cols) '' | tr ' ' -
-    printf "-- Testing segment: %s --\n\n" $seg
+    println "Testing segment: $seg"
 
     if functions fltest_$seg > /dev/null
         eval fltest_$seg
     else
-        printf "No test availlable for segment: %s\n\n" $seg
+        printf "No test availlable for segment: %s\n" $seg
     end
+    printf "\n"
 
 end
-printf '%*s\r' (tput cols) '' | tr ' ' -
-printf "-- Done Testing --\n\n" $seg
+println "Done Testing "

--- a/tests/run.fish
+++ b/tests/run.fish
@@ -80,6 +80,7 @@ echo
 # Load themes
 for theme in $themes
     println "Loading theme: $theme"
+    source $theme
 end
 
 # Run tests

--- a/themes/default_256_colors.fish
+++ b/themes/default_256_colors.fish
@@ -26,7 +26,7 @@ set FLCLR_STATUS_FG         white
 set FLCLR_WRITE_BG          $__256_red
 set FLCLR_WRITE_FG          white
 
-# Color for ARROW  segment
+# Color for ARROW segment
 set FLCLR_ARROW_BG          4e4e4e
 set FLCLR_ARROW_FG          white
 
@@ -36,11 +36,11 @@ set FLCLR_ROOT_FG_USER      white
 set FLCLR_ROOT_BG_ROOT      $__256_red
 set FLCLR_ROOT_FG_ROOT      white
 
-# Color for VFISH  segment
+# Color for VFISH segment
 set FLCLR_VFISH_BG          $__256_green
 set FLCLR_VFISH_FG          black
 
-# Color for CONDA  segment
+# Color for CONDA segment
 set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
 set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
 
@@ -86,9 +86,9 @@ set FLCLR_VIMODE_VISUAL_FG  white
 set FLCLR_SEPARATOR_BG      black
 set FLCLR_SEPARATOR_FG      white
 
-# Color for FISH segment
+# Color for FISH segment
 set FLCLR_FISH              $__256_yellow
 
-# Color for FISH segment when not using Powerline glyph in your theme
+# Color for FISH segment when not using Powerline glyph in your theme
 set FLCLR_FISH_FG           $__256_yellow
 set FLCLR_FISH_BG           normal

--- a/themes/default_256_colors.fish
+++ b/themes/default_256_colors.fish
@@ -39,6 +39,10 @@ set FLCLR_ROOT_FG_ROOT      white
 set FLCLR_VFISH_BG          $__256_green
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
+set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      $__256_yellow
 set FLCLR_GIT_FG_CLEAN      black

--- a/themes/default_256_colors.fish
+++ b/themes/default_256_colors.fish
@@ -7,6 +7,7 @@ set __256_grey              4e4e4e
 set __256_green             5d5
 set __256_yellow            fd0
 set __256_purple            868
+set __256_cyan              688
 set __256_white             eee
 
 # Color for PWD and FULLPWD segment
@@ -66,6 +67,10 @@ set FLCLR_JOBS_FG           black
 # Color for EXECTIME segment
 set FLCLR_EXECTIME_BG       $__256_red
 set FLCLR_EXECTIME_FG       white
+
+# Color for SCREEN segment
+set FLCLR_SCREEN_BG         $__256_cyan
+set FLCLR_SCREEN_FG         white
 
 # Color for VIMODE segment
 set FLCLR_VIMODE_DEFAULT_BG $__256_green

--- a/themes/default_ansi_colors.fish
+++ b/themes/default_ansi_colors.fish
@@ -59,6 +59,10 @@ set FLCLR_JOBS_FG           normal
 set FLCLR_EXECTIME_BG       red
 set FLCLR_EXECTIME_FG       black
 
+# Color for SCREEN segment
+set FLCLR_SCREEN_BG         cyan
+set FLCLR_SCREEN_FG         white
+
 # Color for VIMODE segment
 set FLCLR_VIMODE_DEFAULT_BG green
 set FLCLR_VIMODE_DEFAULT_FG black

--- a/themes/default_ansi_colors.fish
+++ b/themes/default_ansi_colors.fish
@@ -27,11 +27,11 @@ set FLCLR_ROOT_FG_USER      black
 set FLCLR_ROOT_BG_ROOT      red
 set FLCLR_ROOT_FG_ROOT      normal
 
-# Color for VFISH  segment
+# Color for VFISH segment
 set FLCLR_VFISH_BG          green
 set FLCLR_VFISH_FG          black
 
-# Color for CONDA  segment
+# Color for CONDA segment
 set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
 set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
 

--- a/themes/default_ansi_colors.fish
+++ b/themes/default_ansi_colors.fish
@@ -31,6 +31,10 @@ set FLCLR_ROOT_FG_ROOT      normal
 set FLCLR_VFISH_BG          green
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
+set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      yellow
 set FLCLR_GIT_FG_CLEAN      black

--- a/themes/default_symbols.fish
+++ b/themes/default_symbols.fish
@@ -33,6 +33,9 @@ set FLSYM_ROOT_USER         "\u2192"
 # Symbol for VFISH segment
 set FLSYM_VFISH             "\u2635"
 
+# Symbol for CONDA segment
+set FLSYM_CONDA             "\U223F"
+
 # Symbol for VIMODE segment
 set FLSYM_VIMODE_DEFAULT    "NORMAL"
 set FLSYM_VIMODE_INSERT     "INSERT"

--- a/themes/default_symbols.fish
+++ b/themes/default_symbols.fish
@@ -31,13 +31,13 @@ set FLSYM_ROOT_ROOT         "\u221E"
 set FLSYM_ROOT_USER         "\u2192"
 
 # Symbol for VFISH segment
-set FLSYM_VFISH             "\u2635"
+set FLSYM_VFISH             "\u2635 "
 
 # Symbol for CONDA segment
-set FLSYM_CONDA             "\u223F"
+set FLSYM_CONDA             "\u223F "
 
 # Symbol for SCREEN segment
-set FLSYM_SCREEN            "\u239A"
+set FLSYM_SCREEN            "\u239A "
 
 # Symbol for VIMODE segment
 set FLSYM_VIMODE_DEFAULT    "NORMAL"

--- a/themes/default_symbols.fish
+++ b/themes/default_symbols.fish
@@ -34,7 +34,10 @@ set FLSYM_ROOT_USER         "\u2192"
 set FLSYM_VFISH             "\u2635"
 
 # Symbol for CONDA segment
-set FLSYM_CONDA             "\U223F"
+set FLSYM_CONDA             "\u223F"
+
+# Symbol for SCREEN segment
+set FLSYM_SCREEN            "\u239A"
 
 # Symbol for VIMODE segment
 set FLSYM_VIMODE_DEFAULT    "NORMAL"

--- a/themes/legacy_256_colors.fish
+++ b/themes/legacy_256_colors.fish
@@ -17,7 +17,7 @@ set FLCLR_STATUS_FG         normal
 set FLCLR_WRITE_BG          A22
 set FLCLR_WRITE_FG          normal
 
-# Color for ARROW  segment
+# Color for ARROW segment
 set FLCLR_ARROW_BG          444
 set FLCLR_ARROW_FG          normal
 
@@ -27,11 +27,11 @@ set FLCLR_ROOT_FG_USER      normal
 set FLCLR_ROOT_BG_ROOT      red
 set FLCLR_ROOT_FG_ROOT      normal
 
-# Color for VFISH  segment
+# Color for VFISH segment
 set FLCLR_VFISH_BG          green
 set FLCLR_VFISH_FG          black
 
-# Color for CONDA  segment
+# Color for CONDA segment
 set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
 set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
 

--- a/themes/legacy_256_colors.fish
+++ b/themes/legacy_256_colors.fish
@@ -59,6 +59,10 @@ set FLCLR_JOBS_FG           normal
 set FLCLR_EXECTIME_BG       red
 set FLCLR_EXECTIME_FG       black
 
+# Color for SCREEN segment
+set FLCLR_SCREEN_BG         cyan
+set FLCLR_SCREEN_FG         white
+
 # Color for VIMODE segment
 set FLCLR_VIMODE_DEFAULT_BG green
 set FLCLR_VIMODE_DEFAULT_FG black

--- a/themes/legacy_256_colors.fish
+++ b/themes/legacy_256_colors.fish
@@ -31,6 +31,10 @@ set FLCLR_ROOT_FG_ROOT      normal
 set FLCLR_VFISH_BG          green
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
+set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      yellow
 set FLCLR_GIT_FG_CLEAN      black

--- a/themes/tty_compatible.fish
+++ b/themes/tty_compatible.fish
@@ -70,7 +70,7 @@ set FLCLR_STATUS_FG         red
 set FLCLR_WRITE_BG          normal
 set FLCLR_WRITE_FG          red
 
-# Color for ARROW  segment
+# Color for ARROW segment
 set FLCLR_ARROW_BG          normal
 set FLCLR_ARROW_FG          white
 
@@ -80,9 +80,13 @@ set FLCLR_ROOT_FG_USER      white
 set FLCLR_ROOT_BG_ROOT      normal
 set FLCLR_ROOT_FG_ROOT      red
 
-# Color for VFISH  segment
+# Color for VFISH segment
 set FLCLR_VFISH_BG          normal
 set FLCLR_VFISH_FG          green
+
+# Color for CONDA segment
+set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
+set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
 
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      normal
@@ -105,8 +109,8 @@ set FLCLR_JOBS_BG           normal
 set FLCLR_JOBS_FG           brown
 
 # Color for SCREEN segment
-set FLCLR_SCREEN_BG         cyan
-set FLCLR_SCREEN_FG         white
+set FLCLR_SCREEN_BG         normal
+set FLCLR_SCREEN_FG         cyan
 
 # Color for SEPARATOR segment
 set FLCLR_SEPARATOR_BG      normal

--- a/themes/tty_compatible.fish
+++ b/themes/tty_compatible.fish
@@ -36,6 +36,9 @@ set FLSYM_ROOT_USER         "\$"
 # Symbol for VFISH segment
 set FLSYM_VFISH             "#"
 
+# Symbol for CONDA segment
+set FLSYM_CONDA             "conda:"
+
 # Symbol for VIMODE segment
 set FLSYM_VIMODE_DEFAULT    "NORMAL"
 set FLSYM_VIMODE_INSERT     "INSERT"

--- a/themes/tty_compatible.fish
+++ b/themes/tty_compatible.fish
@@ -39,6 +39,9 @@ set FLSYM_VFISH             "#"
 # Symbol for CONDA segment
 set FLSYM_CONDA             "conda:"
 
+# Symbol for SCREEN segment
+set FLSYM_SCREEN            "screen:"
+
 # Symbol for VIMODE segment
 set FLSYM_VIMODE_DEFAULT    "NORMAL"
 set FLSYM_VIMODE_INSERT     "INSERT"
@@ -100,6 +103,10 @@ set FLCLR_USERHOST_FG       purple
 # Color for JOBS segment
 set FLCLR_JOBS_BG           normal
 set FLCLR_JOBS_FG           brown
+
+# Color for SCREEN segment
+set FLCLR_SCREEN_BG         cyan
+set FLCLR_SCREEN_FG         white
 
 # Color for SEPARATOR segment
 set FLCLR_SEPARATOR_BG      normal

--- a/themes/tty_compatible.fish
+++ b/themes/tty_compatible.fish
@@ -108,6 +108,10 @@ set FLCLR_USERHOST_FG       purple
 set FLCLR_JOBS_BG           normal
 set FLCLR_JOBS_FG           brown
 
+# Color for EXECTIME segment
+set FLCLR_EXECTIME_BG       normal
+set FLCLR_EXECTIME_FG       red
+
 # Color for SCREEN segment
 set FLCLR_SCREEN_BG         normal
 set FLCLR_SCREEN_FG         cyan

--- a/themes/tty_compatible.fish
+++ b/themes/tty_compatible.fish
@@ -34,7 +34,7 @@ set FLSYM_ROOT_ROOT         "#"
 set FLSYM_ROOT_USER         "\$"
 
 # Symbol for VFISH segment
-set FLSYM_VFISH             "#"
+set FLSYM_VFISH             "vfish:"
 
 # Symbol for CONDA segment
 set FLSYM_CONDA             "conda:"

--- a/themes/washed.fish
+++ b/themes/washed.fish
@@ -20,7 +20,7 @@ set FLCLR_STATUS_FG         white
 set FLCLR_WRITE_BG          FF875F
 set FLCLR_WRITE_FG          FFFFFF
 
-# Color for ARROW  segment
+# Color for ARROW segment
 set FLCLR_ARROW_BG          $FLCLR_PWD_BG
 set FLCLR_ARROW_FG          $FLCLR_PWD_FG
 
@@ -30,11 +30,11 @@ set FLCLR_ROOT_FG_USER      $FLCLR_PWD_FG
 set FLCLR_ROOT_BG_ROOT      red
 set FLCLR_ROOT_FG_ROOT      $FLCLR_PWD_FG
 
-# Color for VFISH  segment
+# Color for VFISH segment
 set FLCLR_VFISH_BG          AFD787
 set FLCLR_VFISH_FG          black
 
-# Color for CONDA  segment
+# Color for CONDA segment
 set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
 set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
 

--- a/themes/washed.fish
+++ b/themes/washed.fish
@@ -34,6 +34,10 @@ set FLCLR_ROOT_FG_ROOT      $FLCLR_PWD_FG
 set FLCLR_VFISH_BG          AFD787
 set FLCLR_VFISH_FG          black
 
+# Color for CONDA  segment
+set FLCLR_CONDA_BG          $FLCLR_VFISH_BG
+set FLCLR_CONDA_FG          $FLCLR_VFISH_FG
+
 # Color for GIT segment
 set FLCLR_GIT_BG_CLEAN      AFD787
 set FLCLR_GIT_FG_CLEAN      262626

--- a/themes/washed.fish
+++ b/themes/washed.fish
@@ -55,8 +55,8 @@ set FLCLR_USERHOST_BG       c0c0c0
 set FLCLR_USERHOST_FG       808080
 
 # Color for JOBS segment
-set FLCLR_JOBS_BG         	808080
-set FLCLR_JOBS_FG         	00FFFF
+set FLCLR_JOBS_BG           808080
+set FLCLR_JOBS_FG           00FFFF
 
 # Color for SCREEN segment
 set FLCLR_SCREEN_BG         060808

--- a/themes/washed.fish
+++ b/themes/washed.fish
@@ -57,3 +57,7 @@ set FLCLR_USERHOST_FG       808080
 # Color for JOBS segment
 set FLCLR_JOBS_BG         	808080
 set FLCLR_JOBS_FG         	00FFFF
+
+# Color for SCREEN segment
+set FLCLR_SCREEN_BG         060808
+set FLCLR_SCREEN_FG         FFFFFF

--- a/themes/washed.fish
+++ b/themes/washed.fish
@@ -59,5 +59,5 @@ set FLCLR_JOBS_BG           808080
 set FLCLR_JOBS_FG           00FFFF
 
 # Color for SCREEN segment
-set FLCLR_SCREEN_BG         060808
+set FLCLR_SCREEN_BG         608080
 set FLCLR_SCREEN_FG         FFFFFF


### PR DESCRIPTION
## Description

This new version of `fishline` contains two new segment (`screen` and `conda`) as well as a bugfix in the `tests/run.fish` script.

Thanks a lot to @bmcfee for his contributions to this new version !

## Changelog
### Major changes
- New segment `screen`:
  - Shows session name when running inside a screen session (based on the `STY` environment variable).
  - Added by @bmcfee in https://github.com/0rax/fishline/pull/24.
- New segment `conda`:
  - Shows current Conda environment (based on the `CONDA_DEFAULT_ENV` environment variable).
  - Added by @bmcfee in https://github.com/0rax/fishline/pull/23.

### Minor changes
- Update `tty-compatible` them to use the `vfish:` symbol for the `vfish` segment instead of the not so clear `#`.

### Bugfixes
- Updated `tests/run.fish` to fix some potential bugs:
  - Fixed a potential issue when not having a variable set when calling `read` (see https://github.com/fish-shell/fish-shell/issues/4206#issuecomment-315630235).
  - Fixed a potential issue when using `printf` to print a format string starting with `-- ` (which currently fails on current HEAD@`9ef47a4`). We will now be using `__` instead which also makes its output cleaner with some fonts.
  - The script now uses `git rev-parse --show-toplevel` to get the `FLINE_PATH` instead of using weird path arithmetic to prevent potential weird behavior.
- Updated `themes/tty_compatible.fish` to never print a background color (which was not the case for `exectime`).
- Updated the `pwd` segment to fix an issue where `/usr` was shown as is and not just as a `usr` in a segment (which is the expected behavior).