### PR TITLE
Add a segment for just the username, without host

### DIFF
--- a/segments/__flseg_user.fish
+++ b/segments/__flseg_user.fish
@@ -1,0 +1,9 @@
+#!/usr/bin/env fish
+# -*-  mode:fish; tab-width:4  -*-
+
+function __flseg_user
+
+    __fishline_segment $FLCLR_USER_BG $FLCLR_USER_FG
+    printf $USER
+
+end

--- a/segments/__flseg_user.fish
+++ b/segments/__flseg_user.fish
@@ -3,7 +3,7 @@
 
 function __flseg_user
 
-    __fishline_segment $FLCLR_USERHOST_BG $FLCLR_USERHOST_FG
+    __fishline_segment $FLCLR_USER_BG $FLCLR_USER_FG
     printf $USER
 
 end

--- a/segments/__flseg_user.fish
+++ b/segments/__flseg_user.fish
@@ -3,7 +3,7 @@
 
 function __flseg_user
 
-    __fishline_segment $FLCLR_USER_BG $FLCLR_USER_FG
+    __fishline_segment $FLCLR_USERHOST_BG $FLCLR_USERHOST_FG
     printf $USER
 
 end

--- a/tests/fltest_user.fish
+++ b/tests/fltest_user.fish
@@ -1,0 +1,8 @@
+#!/usr/bin/env fish
+# -*-  mode:fish; tab-width:4  -*-
+
+function fltest_user
+
+    __fishline_test USER
+
+end

--- a/themes/default_256_colors.fish
+++ b/themes/default_256_colors.fish
@@ -57,8 +57,8 @@ set FLCLR_CLOCK_BG          $__256_blue
 set FLCLR_CLOCK_FG          white
 
 # Color for USER and USERHOST segments
-set FLCLR_USERHOST_FG       black
-set FLCLR_USER_BG       $__256_white
+set FLCLR_USER_BG           $__256_white
+set FLCLR_USER_FG           black
 set FLCLR_USERHOST_BG       $__256_white
 set FLCLR_USERHOST_FG       black
 

--- a/themes/default_256_colors.fish
+++ b/themes/default_256_colors.fish
@@ -56,7 +56,9 @@ set FLCLR_GIT_FG_DETACHED   white
 set FLCLR_CLOCK_BG          $__256_blue
 set FLCLR_CLOCK_FG          white
 
-# Color for USERHOST segment
+# Color for USER and USERHOST segments
+set FLCLR_USERHOST_FG       black
+set FLCLR_USER_BG       $__256_white
 set FLCLR_USERHOST_BG       $__256_white
 set FLCLR_USERHOST_FG       black
 

--- a/themes/default_ansi_colors.fish
+++ b/themes/default_ansi_colors.fish
@@ -47,7 +47,9 @@ set FLCLR_GIT_FG_DETACHED   normal
 set FLCLR_CLOCK_BG          white
 set FLCLR_CLOCK_FG          black
 
-# Color for USERHOST segment
+# Color for USER and USERHOST segments
+set FLCLR_USER_BG       cyan
+set FLCLR_USER_FG       normal
 set FLCLR_USERHOST_BG       cyan
 set FLCLR_USERHOST_FG       normal
 

--- a/themes/default_ansi_colors.fish
+++ b/themes/default_ansi_colors.fish
@@ -48,8 +48,8 @@ set FLCLR_CLOCK_BG          white
 set FLCLR_CLOCK_FG          black
 
 # Color for USER and USERHOST segments
-set FLCLR_USER_BG       cyan
-set FLCLR_USER_FG       normal
+set FLCLR_USER_BG           cyan
+set FLCLR_USER_FG           normal
 set FLCLR_USERHOST_BG       cyan
 set FLCLR_USERHOST_FG       normal
 


### PR DESCRIPTION
I like having just the username and using colors to differentiate different hosts (mostly due to the silliness that is my university's network and how it messes with hostnames)