### PR TITLE
Fix issues with fish_function_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ git clone https://github.com/0rax/fishline.git/ ~/.config/fish/fishline
 
 Then modify your `~/.config/fish/config.fish` and add:
 ```sh
-set FLINE_PATH $HOME/.config/fish/fishline
-source $FLINE_PATH/init.fish
+if status is-interactive
+    set FLINE_PATH $HOME/.config/fish/fishline
+    source $FLINE_PATH/init.fish
+end
 ```
 
 ### Using [Fisherman](https://github.com/fisherman/fisherman)

--- a/init.fish
+++ b/init.fish
@@ -15,11 +15,11 @@ if test -z "$FLINE_INIT"
     # Use FLINE_PATH to load internals, functions and segments
     if [ "$FLINE_PATH" = "$HOME/.config/fish/conf.d" -a -d "$HOME/.config/fisherman/fishline" ]
         # Assumes fishline has been installed using fisherman on system without realpath
-        set -g FLINE_PATH $HOME/.config/fisherman/fishline
-        set -g fish_function_path $fish_function_path $FLINE_PATH/internals $FLINE_PATH/segments
+        set -gx FLINE_PATH $HOME/.config/fisherman/fishline
+        set -ga fish_function_path $FLINE_PATH/internals $FLINE_PATH/segments
     else
         # Standard installation, add function loading path
-        set -g fish_function_path $fish_function_path $FLINE_PATH/functions $FLINE_PATH/internals $FLINE_PATH/segments
+        set -ga fish_function_path $FLINE_PATH/functions $FLINE_PATH/internals $FLINE_PATH/segments
     end
 end
 

--- a/init.fish
+++ b/init.fish
@@ -10,14 +10,17 @@ if test -z "$FLINE_PATH"
     end
 end
 
-# Use FLINE_PATH to load internals, functions and segments
-if [ "$FLINE_PATH" = "$HOME/.config/fish/conf.d" -a -d "$HOME/.config/fisherman/fishline" ]
-    # Assumes fishline has been installed using fisherman on system without realpath
-    set -gx FLINE_PATH $HOME/.config/fisherman/fishline
-    set -gx fish_function_path $fish_function_path $FLINE_PATH/internals $FLINE_PATH/segments
-else
-    # Standard installation, add function loading path
-    set -gx fish_function_path $fish_function_path $FLINE_PATH/functions $FLINE_PATH/internals $FLINE_PATH/segments
+if test -z "$FLINE_INIT"
+    set -g "$FLINE_INIT" true
+    # Use FLINE_PATH to load internals, functions and segments
+    if [ "$FLINE_PATH" = "$HOME/.config/fish/conf.d" -a -d "$HOME/.config/fisherman/fishline" ]
+        # Assumes fishline has been installed using fisherman on system without realpath
+        set -g FLINE_PATH $HOME/.config/fisherman/fishline
+        set -g fish_function_path $fish_function_path $FLINE_PATH/internals $FLINE_PATH/segments
+    else
+        # Standard installation, add function loading path
+        set -g fish_function_path $fish_function_path $FLINE_PATH/functions $FLINE_PATH/internals $FLINE_PATH/segments
+    end
 end
 
 # Load default color theme based on tput output

--- a/init.fish
+++ b/init.fish
@@ -10,8 +10,8 @@ if test -z "$FLINE_PATH"
     end
 end
 
-if test -z "$FLINE_INIT"
-    set -g "$FLINE_INIT" true
+if set -q FLINE_INIT
+    set -g FLINE_INIT true
     # Use FLINE_PATH to load internals, functions and segments
     if [ "$FLINE_PATH" = "$HOME/.config/fish/conf.d" -a -d "$HOME/.config/fisherman/fishline" ]
         # Assumes fishline has been installed using fisherman on system without realpath


### PR DESCRIPTION
Fixes two issues:
- `fish_function_path` was getting exported, causing child fish processes to have a malformed function path (see [#5348](https://github.com/fish-shell/fish-shell/issues/5348))
- `fish_function_path` was being cluttered with multiple entries when sourcing init.fish multiple times (such as when updating config.fish). This didn't cause issues, but did get annoying (see #30). 