### PR TITLE
Replace ^^ by 2> for fish 3.3

### DIFF
--- a/segments/__flseg_git.fish
+++ b/segments/__flseg_git.fish
@@ -3,26 +3,26 @@
 
 function __flseg_git
 
-    if git rev-parse --git-dir >> /dev/null ^^ /dev/null
+    if git rev-parse --git-dir >> /dev/null 2> /dev/null
 
         set -l detached 0
         set -l ahead 0
         set -l behind 0
-        set -l branch (git rev-parse --abbrev-ref HEAD ^^ /dev/null)
+        set -l branch (git rev-parse --abbrev-ref HEAD 2> /dev/null)
 
         if [ "$status" -ne 0 ] # Repository is empty
             set branch (git status —porcelain -b | head -n1 | cut -d' ' -f 3-)
             set detached 1
         else if [ "$branch" = "HEAD" ] # Repository is detached on tags / commit
-            set branch (git describe --tags --exact-match ^^ /dev/null; or git log --format=%h --abbrev-commit -1 ^^ /dev/null)
+            set branch (git describe --tags --exact-match 2> /dev/null; or git log --format=%h --abbrev-commit -1 2> /dev/null)
             set detached 1
-        else if git rev-parse --verify --quiet origin/$branch ^^ /dev/null >> /dev/null
+        else if git rev-parse --verify --quiet origin/$branch 2> /dev/null >> /dev/null
             set ahead (git rev-list origin/$branch..$branch | wc -l)
             set behind (git rev-list $branch..origin/$branch | wc -l)
         end
 
         # http://git-scm.com/docs/git-status
-        set -l gitstatus (git status --porcelain ^^ /dev/null | cut -c 1-2 | awk 'BEGIN {s=0; n=0; u=0; t=0}; /^[MARCDU].$/ {s=1}; /^.[MDAU]$/ {n=1}; /^\?\?$/ {u=1}; {t=s+n+u} END {printf("%s\n%d\n%d\n%d", t, s, n, u)}')
+        set -l gitstatus (git status --porcelain 2> /dev/null | cut -c 1-2 | awk 'BEGIN {s=0; n=0; u=0; t=0}; /^[MARCDU].$/ {s=1}; /^.[MDAU]$/ {n=1}; /^\?\?$/ {u=1}; {t=s+n+u} END {printf("%s\n%d\n%d\n%d", t, s, n, u)}')
         # bool gitstatus[1] any changes
         # bool gitstatus[2] staged changes
         # bool gitstatus[3] unstaged changes


### PR DESCRIPTION
Fish is deprecating ^ as a redirect to stderr, so this PR updates the git segment of fishline to use 2> instead when calling git.  I don't think an append (`2>>`) is necessary here, as all redirects are to /dev/null.

