### PR TITLE
Fix false-positive check for tty in flatpak

### DIFF
--- a/conf.d/fishline-init.fish
+++ b/conf.d/fishline-init.fish
@@ -13,7 +13,11 @@ end
 source $FLINE_THEME_DIR/default_symbols.fish
 
 # Load default color theme depending on terminal capabilities
-if begin; [ (uname) != "Darwin" ]; and tty | grep tty > /dev/null; end
+if begin
+		[ (uname) != "Darwin" ]
+		and set -l out (tty)
+		and string match -eq "tty" $out
+	end
     # Emable a TTY safe default theme if a TTY is detected
 	source $FLINE_THEME_DIR/tty_compatible.fish
 else if begin; not command -s tput > /dev/null; or [ (tput colors) -lt 256 ]; end


### PR DESCRIPTION
When there is absolutely no tty set at all (e.g. in a shell spawned by
a flatpak), tty prints `not a tty`, which matches the current check `tty | grep "tty"`.

In normal shells it prints something like `/dev/pts/0`, in actual ttys it prints something like `/dev/tty1`.

Luckily `tty` also returns `1`, so we can do a two-stage check instead:

```fish
# Capture tty's output in a local variable
# set doesn't modify the return status of tty
set --local out (tty)

# If tty returned non-zero, search its output
and string match --quiet --entire "tty" $out
```

- A more robust check might use a regex to check:

```fish
string match --quiet --regex --entire '/ttyS?\d+$' $out
```

I figured it's better to use the faster substring matching rather than regex matching, especially if this is run every time a prompt is generated, but if not - or if you'd rather be more robust - let me know.

This fixes #38